### PR TITLE
Flatten kwargs for "outlier" issue type

### DIFF
--- a/cleanlab/experimental/datalab/datalab.py
+++ b/cleanlab/experimental/datalab/datalab.py
@@ -360,14 +360,21 @@ class Datalab:
             return self.issues
 
         specific_issues = self._get_matching_issue_columns(issue_name)
+        info = self.get_info(issue_name=issue_name)
         if issue_name == "label":
-            label_info = self.get_info(issue_name=issue_name)
-            predicted_labels = np.vectorize(self._data._label_map.get)(
-                label_info["predicted_label"]
-            )
+            label_map = self._data._label_map.get
+            predicted_labels = np.vectorize(label_map)(info["predicted_label"])
             label_name = cast(str, self.label_name)
             specific_issues = specific_issues.assign(
                 given_label=self._data._data[label_name], predicted_label=predicted_labels
+            )
+
+        if issue_name in ["outlier", "near_duplicate"]:
+            nearest_neighbor = info["nearest_neighbor"]
+            distance_to_nearest_neighbor = info["distance_to_nearest_neighbor"]
+            specific_issues = specific_issues.assign(
+                nearest_neighbor=nearest_neighbor,
+                distance_to_nearest_neighbor=distance_to_nearest_neighbor,
             )
         return specific_issues
 

--- a/cleanlab/experimental/datalab/issue_manager/duplicate.py
+++ b/cleanlab/experimental/datalab/issue_manager/duplicate.py
@@ -139,7 +139,7 @@ class NearDuplicateIssueManager(IssueManager):
         knn_info_dict = {
             "nearest_neighbor": nn_ids.tolist(),
             "distance_to_nearest_neighbor": dists.tolist(),
-            "weighted_knn_graph": weighted_knn_graph.toarray().tolist(),
+            "weighted_knn_graph": weighted_knn_graph,
         }
 
         info_dict = {

--- a/cleanlab/experimental/datalab/issue_manager/noniid.py
+++ b/cleanlab/experimental/datalab/issue_manager/noniid.py
@@ -151,7 +151,7 @@ class NonIIDIssueManager(IssueManager):
 
         self.num_neighbors = self.k
         self.num_non_neighbors = min(
-            10 * self.num_neighbors, len(self.neighbor_graph) - self.num_neighbors - 1
+            10 * self.num_neighbors, self.neighbor_graph.shape[0] - self.num_neighbors - 1
         )
         self.neighbor_index_distances = self._sample_neighbors(num_samples=self.num_neighbors)
         self.non_neighbor_index_distances = self._sample_non_neighbors(
@@ -217,7 +217,7 @@ class NonIIDIssueManager(IssueManager):
         return self._histogram1d
 
     def _permutation_test(self, num_permutations) -> float:
-        N = len(self.neighbor_graph)
+        N = self.neighbor_graph.shape[0]
         tiled = np.tile(np.arange(N), (N, 1))
         index_distances = tiled - tiled.T
 
@@ -252,7 +252,8 @@ class NonIIDIssueManager(IssueManager):
         graph = self.neighbor_graph
         scores = {}
 
-        num_bins = len(graph) - 1
+        N = graph.shape[0]
+        num_bins = N - 1
         bin_range = (1, num_bins)
 
         neighbor_cdfs = self._compute_row_cdf(self.neighbor_index_distances, num_bins, bin_range)
@@ -262,8 +263,8 @@ class NonIIDIssueManager(IssueManager):
 
         stats = np.sum(np.abs(neighbor_cdfs - non_neighbor_cdfs), axis=1)
 
-        indices = np.arange(len(graph))
-        reverse = len(graph) - indices
+        indices = np.arange(N)
+        reverse = N - indices
         normalizer = np.where(indices > reverse, indices, reverse)
 
         scores = stats / normalizer
@@ -309,7 +310,7 @@ class NonIIDIssueManager(IssueManager):
 
     def _sample_distances(self, sample_neighbors, distances=None, num_samples=1) -> np.ndarray:
         graph = self.neighbor_graph
-        N = len(graph)
+        N = graph.shape[0]
         all_idx = np.arange(N)
         all_idx = np.tile(all_idx, (N, 1))
         if sample_neighbors:
@@ -336,7 +337,7 @@ class NonIIDIssueManager(IssueManager):
 
     def _build_histogram(self, index_array) -> np.ndarray:
         histogram1d = self._get_histogram1d()
-        num_bins = len(self.neighbor_graph) - 1
+        num_bins = self.neighbor_graph.shape[0] - 1
         bin_range = (1, num_bins)
         histogram = histogram1d(index_array, num_bins, bin_range)
         histogram = histogram / len(index_array)

--- a/cleanlab/experimental/datalab/issue_manager/noniid.py
+++ b/cleanlab/experimental/datalab/issue_manager/noniid.py
@@ -193,7 +193,7 @@ class NonIIDIssueManager(IssueManager):
         weighted_knn_graph = self.knn.kneighbors_graph(mode="distance")  # type: ignore[union-attr]
 
         knn_info_dict = {
-            "weighted_knn_graph": weighted_knn_graph.toarray().tolist(),
+            "weighted_knn_graph": weighted_knn_graph,
         }
 
         info_dict = {
@@ -285,8 +285,8 @@ class NonIIDIssueManager(IssueManager):
         item i and j are nth nearest neighbors. For n > k, A[i,j] = -1. Additionally, A[i,i] = 0
         """
 
-        distances, kneighbors = knn.kneighbors()
-        graph = knn.kneighbors_graph(n_neighbors=self.k).toarray()
+        _, kneighbors = knn.kneighbors()
+        graph = knn.kneighbors_graph(n_neighbors=self.k)
 
         kneighbor_graph = np.ones(graph.shape) * -1
         for i, nbrs in enumerate(kneighbors):

--- a/cleanlab/experimental/datalab/issue_manager/noniid.py
+++ b/cleanlab/experimental/datalab/issue_manager/noniid.py
@@ -217,16 +217,14 @@ class NonIIDIssueManager(IssueManager):
         return self._histogram1d
 
     def _permutation_test(self, num_permutations) -> float:
-        graph = self.neighbor_graph
-        tiled = np.tile(np.arange(len(graph)), (len(graph), 1))
-        index_distances = tiled - tiled.transpose()
-        neighbors = graph > 0
-        others = graph < 0
+        N = len(self.neighbor_graph)
+        tiled = np.tile(np.arange(N), (N, 1))
+        index_distances = tiled - tiled.T
 
         statistics = []
-        for i in range(num_permutations):
-            perm = np.random.permutation(len(graph))
-            distance = (perm - np.arange(len(graph))).reshape(len(graph), 1)
+        for _ in range(num_permutations):
+            perm = np.random.permutation(N)
+            distance = (perm - np.arange(N)).reshape(N, 1)
             new_distances = np.abs(distance - index_distances - distance.transpose())
 
             neighbor_index_distances = self._sample_neighbors(
@@ -311,18 +309,19 @@ class NonIIDIssueManager(IssueManager):
 
     def _sample_distances(self, sample_neighbors, distances=None, num_samples=1) -> np.ndarray:
         graph = self.neighbor_graph
-        all_idx = np.arange(len(graph))
-        all_idx = np.tile(all_idx, (len(graph), 1))
+        N = len(graph)
+        all_idx = np.arange(N)
+        all_idx = np.tile(all_idx, (N, 1))
         if sample_neighbors:
-            indices = all_idx[graph > 0].reshape(len(graph), -1)
+            indices = all_idx[graph > 0].reshape(N, -1)
         else:
-            indices = all_idx[graph < 0].reshape(len(graph), -1)
+            indices = all_idx[graph < 0].reshape(N, -1)
         generator = np.random.default_rng()
         choices = generator.choice(indices, axis=1, size=num_samples, replace=False)
         if distances is None:
-            sample_distances = np.abs(np.arange(len(graph)) - choices.transpose()).transpose()
+            sample_distances = np.abs(np.arange(N) - choices.transpose()).transpose()
         else:
-            sample_distances = distances[np.arange(len(graph)), choices.transpose()].transpose()
+            sample_distances = distances[np.arange(N), choices.transpose()].transpose()
         return sample_distances
 
     def _sample_neighbors(self, distances=None, num_samples=1) -> np.ndarray:

--- a/cleanlab/experimental/datalab/issue_manager/outlier.py
+++ b/cleanlab/experimental/datalab/issue_manager/outlier.py
@@ -57,12 +57,24 @@ class OutOfDistributionIssueManager(IssueManager):
     def __init__(
         self,
         datalab: Datalab,
-        ood_kwargs: Optional[Dict[str, Any]] = None,
         threshold: Optional[float] = None,
-        **_,
+        **kwargs,
     ):
         super().__init__(datalab)
-        self.ood: OutOfDistribution = OutOfDistribution(**(ood_kwargs or {}))
+
+        ood_kwargs = kwargs.get("ood_kwargs", {})
+
+        valid_ood_params = OutOfDistribution.DEFAULT_PARAM_DICT.keys()
+        params = {
+            key: value
+            for key, value in ((k, kwargs.get(k, None)) for k in valid_ood_params)
+            if value is not None
+        }
+
+        if params:
+            ood_kwargs["params"] = params
+
+        self.ood: OutOfDistribution = OutOfDistribution(**ood_kwargs)
         self.threshold = threshold
         self._embeddings: Optional[np.ndarray] = None
 

--- a/cleanlab/experimental/datalab/issue_manager/outlier.py
+++ b/cleanlab/experimental/datalab/issue_manager/outlier.py
@@ -113,7 +113,7 @@ class OutOfDistributionIssueManager(IssueManager):
         if self.ood.params["knn"] is not None:
             knn = self.ood.params["knn"]
             dists, nn_ids = [array[:, 0] for array in knn.kneighbors()]  # type: ignore[union-attr]
-            weighted_knn_graph = knn.kneighbors_graph(mode="distance").toarray()  # type: ignore[union-attr]
+            weighted_knn_graph = knn.kneighbors_graph(mode="distance")  # type: ignore[union-attr]
 
             # TODO: Reverse the order of the calls to knn.kneighbors() and knn.kneighbors_graph()
             #   to avoid computing the (distance, id) pairs twice.
@@ -123,7 +123,7 @@ class OutOfDistributionIssueManager(IssueManager):
                     "k": knn.n_neighbors,  # type: ignore[union-attr]
                     "nearest_neighbor": nn_ids.tolist(),
                     "distance_to_nearest_neighbor": dists.tolist(),
-                    "weighted_knn_graph": weighted_knn_graph.tolist(),
+                    "weighted_knn_graph": weighted_knn_graph,
                 }
             )
 

--- a/docs/source/tutorials/datalab.ipynb
+++ b/docs/source/tutorials/datalab.ipynb
@@ -354,9 +354,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "lab.find_issues(pred_probs=pred_probs, features=data[\"X\"],\n",
-    "                issue_types={\"outlier\": {\"ood_kwargs\": {\"params\": {\"k\": 80}}}},\n",
-    ")\n",
+    "lab.find_issues(pred_probs=pred_probs, features=data[\"X\"], issue_types={\"outlier\": {\"k\": 80}})\n",
     "lab.report()"
    ]
   },

--- a/docs/source/tutorials/scripts/data_generation.py
+++ b/docs/source/tutorials/scripts/data_generation.py
@@ -60,6 +60,19 @@ def create_data():
     y_train = np.concatenate([y_train, y_out])
     y_train_idx = np.concatenate([y_train_idx, y_out_bin_idx])
 
+    # Add non-iid examples to the training set
+    X_non_iid = np.array([[6.0 + 0.025 * i, 0.5 + np.sin(0.25 * i)] for i in range(25)])
+    y_non_iid = np.sum(X_non_iid, axis=1)
+    y_non_iid_bin = np.array(
+        [k for y_i in y_non_iid for k, v in BINS.items() if v[0] <= y_i < v[1]]
+    )
+    y_non_iid_bin_idx = np.array([BINS_MAP[k] for k in y_non_iid_bin])
+
+    # Add to train
+    X_train = np.concatenate([X_train, X_non_iid])
+    y_train = np.concatenate([y_train, y_non_iid])
+    y_train_idx = np.concatenate([y_train_idx, y_non_iid_bin_idx])
+
     py = np.bincount(y_train_idx) / float(len(y_train_idx))
     m = len(BINS)
 

--- a/tests/datalab/test_datalab.py
+++ b/tests/datalab/test_datalab.py
@@ -73,7 +73,7 @@ class TestDatalab:
                 "predicted_labels": [1, 1, 2],
             },
             "outlier": {
-                "nearest_neighbors": [1, 0, 0],
+                "nearest_neighbor": [1, 0, 0],
             },
         }
         monkeypatch.setattr(lab, "info", mock_info)
@@ -116,7 +116,19 @@ class TestDatalab:
         monkeypatch.setattr(lab, "issues", mock_issues)
 
         mock_predicted_labels = np.array([0, 1, 2, 1, 2])
-        lab.info.update({"label": {"predicted_label": mock_predicted_labels}})
+
+        mock_nearest_neighbor = [1, 3, 5, 2, 0]
+        mock_distance_to_nearest_neighbor = [0.1, 0.2, 0.3, 0.4, 0.5]
+
+        lab.info.update(
+            {
+                "label": {"predicted_label": mock_predicted_labels},
+                "outlier": {
+                    "nearest_neighbor": mock_nearest_neighbor,
+                    "distance_to_nearest_neighbor": mock_distance_to_nearest_neighbor,
+                },
+            }
+        )
 
         label_issues = lab.get_issues(issue_name="label")
 
@@ -135,6 +147,8 @@ class TestDatalab:
         expected_outlier_issues = pd.DataFrame(
             {
                 **{key: mock_issues[key] for key in ["is_outlier_issue", "outlier_score"]},
+                "nearest_neighbor": mock_nearest_neighbor,
+                "distance_to_nearest_neighbor": mock_distance_to_nearest_neighbor,
             },
         )
         pd.testing.assert_frame_equal(outlier_issues, expected_outlier_issues)


### PR DESCRIPTION
The `OutOfDistributionIssueManager` now uses the keys of the default parameters that OutOfDistribution accepts, stored in a class variable, and searches for any kwargs that match those.

Changes to the OutOfDistributionIssueManager.__init__ method are reflected in tutorial notebook.

More unit-tests are added that cover different values of some kwargs.

Fixes elisno/cleanlab#8 via cleanlab/cleanlab#614