### PR TITLE
Create a wrapper for knn search

### DIFF
--- a/.mypy.ini
+++ b/.mypy.ini
@@ -30,6 +30,3 @@ ignore_missing_imports = True
 
 [mypy-scipy.*]
 ignore_missing_imports = True
-
-[mypy-fast_histogram.*]
-ignore_missing_imports = True

--- a/cleanlab/experimental/datalab/issue_manager/outlier.py
+++ b/cleanlab/experimental/datalab/issue_manager/outlier.py
@@ -27,7 +27,6 @@ from cleanlab.experimental.datalab.knn import KNN
 from cleanlab.outlier import OutOfDistribution
 
 if TYPE_CHECKING:  # pragma: no cover
-    from sklearn.neighbors import NearestNeighbors
     from scipy.sparse import csr_matrix
 
     from cleanlab.experimental.datalab.datalab import Datalab

--- a/cleanlab/experimental/datalab/issue_manager/outlier.py
+++ b/cleanlab/experimental/datalab/issue_manager/outlier.py
@@ -155,12 +155,13 @@ class OutOfDistributionIssueManager(IssueManager):
         feature_issues_dict = {}
 
         # Compute
-        if self._knn_graph is not None and self.ood.params["knn"] is not None:
+        graph = self._knn_graph
+        if graph is not None and self.ood.params["knn"] is not None:
             knn = self.ood.params["knn"]  # type: ignore
-            N = self._knn_graph.shape[0]
-            k = self._knn_graph.nnz // N
-            dists = self._knn_graph.data.reshape(N, -1)[:, 0]
-            nn_ids = self._knn_graph.indices.reshape(N, -1)[:, 0]
+            N = graph.shape[0]
+            k = graph.nnz // N
+            dists = graph.data.reshape(N, -1)[:, 0]
+            nn_ids = graph.indices.reshape(N, -1)[:, 0]
 
             feature_issues_dict.update(
                 {

--- a/cleanlab/experimental/datalab/issue_manager/outlier.py
+++ b/cleanlab/experimental/datalab/issue_manager/outlier.py
@@ -23,6 +23,7 @@ import numpy.typing as npt
 import pandas as pd
 
 from cleanlab.experimental.datalab.issue_manager import IssueManager
+from cleanlab.experimental.datalab.knn import KNN
 from cleanlab.outlier import OutOfDistribution
 
 if TYPE_CHECKING:  # pragma: no cover
@@ -107,11 +108,12 @@ class OutOfDistributionIssueManager(IssueManager):
                 self._knn_graph = weighted_knn_graph
                 k = self._knn_graph.nnz // self._knn_graph.shape[0]
 
-            knn: NearestNeighbors = self.ood.params["knn"]  # type: ignore
+            knn = KNN(knn=self.ood.params["knn"])  # type: ignore
+            knn.add_item(self._embeddings)
             if kwargs.get("knn", None) is not None or knn.n_neighbors > k:  # type: ignore[union-attr]
                 # If the pre-existing knn graph has fewer neighbors than the knn object,
                 # then we need to recompute the knn graph
-                self._knn_graph = knn.kneighbors_graph(mode="distance")  # type: ignore[union-attr]
+                self._knn_graph = knn.kneighbors_graph()  # type: ignore[union-attr]
                 self._metric = knn.metric  # type: ignore[union-attr]
                 k = knn.n_neighbors  # type: ignore[union-attr]
             distances = self._knn_graph.data.reshape(-1, k)  # type: ignore[union-attr]

--- a/cleanlab/experimental/datalab/knn.py
+++ b/cleanlab/experimental/datalab/knn.py
@@ -1,0 +1,260 @@
+"""This module contains the KNNGraph class, which is used to find the K nearest neighbors of data points in a dataset and
+represent the dataset as weighted graph adjacency matrix (excluding self-loops).
+"""
+
+from abc import ABC
+import warnings
+import numpy as np
+
+from typing import Optional, Tuple, Union, cast
+from scipy.sparse import csr_matrix
+from sklearn.neighbors import NearestNeighbors
+
+
+class KNNInterface(ABC):
+    """Necessary interface for any class handling KNN search to be compatible with `Datalab`."""
+
+    n_neighbors: int
+
+    def fit(self, features: Union[np.ndarray, csr_matrix]) -> None:
+        raise NotImplementedError
+
+    def kneighbors(
+        self, features: Union[np.ndarray, csr_matrix], n_neighbors=None
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        raise NotImplementedError
+
+
+KNNInterface.register(NearestNeighbors)
+
+
+class KNN:
+    """K-nearest neighbors (KNN) search class.
+
+    This class is used to find the K nearest neighbors of data points in a
+    dataset. This wraps existing KNN search implementations in scikit-learn
+    or any other object that implements the `fit`/`kneighbors` interface.
+
+    This class is opinionated in that it assumes that:
+        - The KNN search object is stateful.
+        - The `fit` method should only be called once.
+        - The `kneighbors` method should return a tuple of neighbor indices
+            and neighbor distances.
+
+    Parameters
+    ----------
+    n_neighbors :
+        Number of neighbors to search for.
+
+        Note: This parameter is overridden if the `knn` parameter is passed.
+
+    knn :
+        KNN search object that implements the `fit`/`kneighbors` interface.
+        If `None`, a NearestNeighbors search object is used.
+    """
+
+    def __init__(self, n_neighbors: int = 5, knn: Optional[KNNInterface] = None) -> None:
+        self.n_neighbors = n_neighbors
+        self.knn = knn
+        self.neighbor_indices: Optional[np.ndarray] = None
+        self.neighbor_distances: Optional[np.ndarray] = None
+        self._knn_graph: Optional[csr_matrix] = None
+        self._fit_features: Optional[Union[np.ndarray, csr_matrix]] = None
+        if self.knn is None:
+            # Use the default KNN search implementation in scikit-learn.
+            self.knn = NearestNeighbors(n_neighbors=self.n_neighbors)
+        try:
+            k = cast(int, self.knn.n_neighbors)  # Cast knn n_neighbors to int
+            if k != self.n_neighbors:
+                warnings.warn(
+                    f"n_neighbors {self.n_neighbors} does not match n_neighbors "
+                    f"{k} used to fit knn. "
+                    "Most likely an existing NearestNeighbors object was passed in, "
+                    "but a different n_neighbors was specified. "
+                    "Using the n_neighbors found in the existing KNN search object."
+                )
+                self.n_neighbors = k
+        except AttributeError:
+            warnings.warn(
+                "KNN search object does not have a n_neighbors attribute. "
+                "Make sure that the number of neighbors being searched for "
+                "does not differ from the n_neighbors parameter."
+            )
+
+    def fit(self, features: Union[np.ndarray, csr_matrix]) -> "KNN":
+        """Fit the KNN search object.
+
+        For convenience, this stores the features as an attribute for easy self-querying,
+        regardless of how the search object builds its index.
+
+        Parameters
+        ----------
+        features :
+            A matrix of features for each data point.
+        """
+        assert self.knn is not None, "KNN search object not initialized, cannot fit."
+        self._fit_features = features
+        self.knn.fit(self._fit_features)
+        return self
+
+    def kneighbors(
+        self,
+        features: Optional[Union[np.ndarray, csr_matrix]] = None,
+        n_neighbors: Optional[int] = None,
+    ) -> Tuple[np.ndarray, np.ndarray]:
+        """Find the K nearest neighbors of each data point.
+
+        Parameters
+        ----------
+        features :
+            A matrix of features for each data point.
+
+        Returns
+        -------
+        neighbor_distances :
+            An array of shape (n_queries, n_neighbors) containing the distances to the
+            nearest neighbors of each query point.
+
+        neighbor_indices :
+            An array of shape (n_queries, n_neighbors) containing the indices of the
+            nearest neighbors of each query point.
+
+        Examples
+        --------
+        >>> from cleanlab.experimental.datalab.knn import KNN
+        >>> knn = KNN(n_neighbors=2)
+        >>> X = [[0.0, 0.4], [1.0, 0.2], [0.6, 0.2], [0.8, 1.0], [0.9, 1.0]]
+        >>> knn.fit(X)
+        >>> dists, ids = knn.kneighbors() # Ignores query points as neighbors
+        >>> dists
+        array([[0.63, 1.  ],
+               [0.4 , 0.81],
+               [0.4 , 0.63],
+               [0.1 , 0.82],
+               [0.1 , 0.81]])
+        >>> ids
+        array([[2, 3],
+               [2, 4],
+               [1, 0],
+               [4, 1],
+               [3, 1]])
+        """
+        index = cast(KNNInterface, self.knn)
+
+        if n_neighbors is None:
+            n_neighbors = self.n_neighbors
+
+        if features is None:
+            if (
+                n_neighbors <= self.n_neighbors
+                and self.neighbor_distances is not None
+                and self.neighbor_indices is not None
+            ):
+                return (
+                    self.neighbor_distances[:, :n_neighbors],
+                    self.neighbor_indices[:, :n_neighbors],
+                )
+            n_neighbors += 1  # Ignore self-querying
+            query = self._fit_features
+            assert query is not None, "KNN search object not fit, cannot find neighbors."
+            try:
+                neighbor_distances, neighbor_indices = index.kneighbors(
+                    query, n_neighbors=n_neighbors
+                )
+                neighbor_distances = neighbor_distances[:, 1:]
+                neighbor_indices = neighbor_indices[:, 1:]
+            except TypeError as e:
+                raise TypeError(
+                    "KNN search object does not have a kneighbors method that accepts "
+                    "the n_neighbors parameter. Make sure that the number of neighbors "
+                    "being searched for does not differ from the n_neighbors parameter."
+                ) from e
+        else:
+            query = features
+            try:
+                neighbor_distances, neighbor_indices = index.kneighbors(
+                    query, n_neighbors=n_neighbors
+                )
+            except TypeError as e:
+                raise TypeError(
+                    "KNN search object does not have a kneighbors method that accepts "
+                    "the n_neighbors parameter. Make sure that the number of neighbors "
+                    "being searched for does not differ from the n_neighbors parameter."
+                ) from e
+
+        if features is None:
+            cache_exists = self.neighbor_distances is not None and self.neighbor_indices is not None
+            cache_too_small = cache_exists and (
+                self.neighbor_distances.shape[0] < neighbor_distances.shape[0]
+                or self.neighbor_distances.shape[1] < neighbor_distances.shape[1]
+            )
+
+            if not cache_exists or cache_too_small:
+                self.neighbor_distances = neighbor_distances
+                self.neighbor_indices = neighbor_indices
+        return neighbor_distances, neighbor_indices
+
+    def kneighbors_graph(
+        self,
+        features: Optional[Union[np.ndarray, csr_matrix]] = None,
+        n_neighbors: Optional[int] = None,
+    ) -> csr_matrix:
+        """Find the K nearest neighbors of each data point and return a graph adjacency matrix.
+
+        Parameters
+        ----------
+        features :
+            A matrix of features for each data point. If this is not
+            specified, then the KNN search object must have been fit before
+
+        n_neighbors :
+            The number of neighbors to search for. If this is not
+            specified, then the KNN search object must have been fit before
+            and the number of neighbors used to fit the KNN search object
+            will be used.
+
+        Returns
+        -------
+        knn_graph :
+            A sparse matrix containing the K nearest neighbors of each data point, weighted by the
+            distance to the nearest neighbor.
+
+                Examples
+        --------
+        >>> from cleanlab.experimental.datalab.knn import KNN
+        >>> knn = KNN(n_neighbors=2)
+        >>> X = [[0.0, 0.4], [1.0, 0.2], [0.6, 0.2], [0.8, 1.0], [0.9, 1.0]]
+        >>> knn.fit(X)
+        >>> graph = knn.kneighbors_graph()
+        >>> graph.toarray()  # Don't do this for large graphs!
+        array([[0.  , 0.  , 0.63, 1.  , 0.  ],
+               [0.  , 0.  , 0.4 , 0.  , 0.81],
+               [0.63, 0.4 , 0.  , 0.  , 0.  ],
+               [0.  , 0.82, 0.  , 0.  , 0.1 ],
+               [0.  , 0.81, 0.  , 0.1 , 0.  ]])
+        """
+        if n_neighbors is None:
+            n_neighbors = self.n_neighbors
+
+        if features is None:
+            cache_available = (
+                n_neighbors <= self.n_neighbors
+                and self.neighbor_distances is not None
+                and self.neighbor_indices is not None
+            )
+            if cache_available:
+                neighbor_distances = cast(np.ndarray, self.neighbor_distances)
+                neighbor_indices = cast(np.ndarray, self.neighbor_indices)
+                dists, ids = neighbor_distances, neighbor_indices
+            else:
+                dists, ids = self.kneighbors(n_neighbors=n_neighbors)
+        else:
+            dists, ids = self.kneighbors(features, n_neighbors=n_neighbors)
+
+        N = ids.shape[0]
+
+        nnz = N * n_neighbors
+        indptr = np.arange(0, nnz + 1, n_neighbors)
+        self._knn_graph = csr_matrix((dists.ravel(), ids.ravel(), indptr), shape=(N, N))
+
+        return self._knn_graph

--- a/cleanlab/experimental/datalab/knn.py
+++ b/cleanlab/experimental/datalab/knn.py
@@ -8,6 +8,7 @@ import numpy as np
 
 from typing import Optional, Tuple, Union, cast
 from scipy.sparse import csr_matrix
+from sklearn.exceptions import NotFittedError
 from sklearn.neighbors import NearestNeighbors
 
 
@@ -156,7 +157,11 @@ class KNN:
                 )
             n_neighbors += 1  # Ignore self-querying
             query = self._fit_features
-            assert query is not None, "KNN search object not fit, cannot find neighbors."
+            if query is None:
+                raise NotFittedError(
+                    "KNN search object not fit, cannot find neighbors. "
+                    "Call the fit() method first."
+                )
             try:
                 neighbor_distances, neighbor_indices = index.kneighbors(
                     query, n_neighbors=n_neighbors
@@ -171,6 +176,11 @@ class KNN:
                 ) from e
         else:
             query = features
+            if self._fit_features is None:
+                raise NotFittedError(
+                    "KNN search object not fit, cannot find neighbors. "
+                    "Call the fit() method first."
+                )
             try:
                 neighbor_distances, neighbor_indices = index.kneighbors(
                     query, n_neighbors=n_neighbors

--- a/docs/source/tutorials/datalab.ipynb
+++ b/docs/source/tutorials/datalab.ipynb
@@ -15,10 +15,37 @@
     "This includes: noisy labels, outliers, (near) duplicates, and other types of problems that commonly occur in real-world data.\n",
     "`Datalab` utilizes *any* ML model you have already trained for your data to diagnose these issues, it only requires access to either: (probabilistic) predictions from your model or its learned representations of the data.\n",
     "\n",
-    "Underneath  the hood, this class calls all the appropriate cleanlab methods for your dataset and provided model outputs, in order to best audit the data and alert you of important issues. This makes it easy to apply many functionalities of this library all within a single line of code. Before considering other cleanlab functions, we recommend considering if `Datalab` can address your needs. That said, `Datalab` is primarily for auditing a classification dataset for potential issues, while other cleanlab methods implement a wide variety of other data-centric AI capabilities.\n",
+    "Underneath the hood, this class calls all the appropriate cleanlab methods for your dataset and provided model outputs, in order to best audit the data and alert you of important issues. This makes it easy to apply many functionalities of this library all within a single line of code. Before considering other cleanlab functions, we recommend considering if `Datalab` can address your needs. That said, `Datalab` is primarily for auditing a classification dataset for potential issues, while other cleanlab methods implement a wide variety of other data-centric AI capabilities.\n",
     "\n",
     "\n",
     "This tutorial demonstrates how to use `Datalab` to identify issues in a (toy) dataset. You can easily replace our demo dataset with your own image/text/tabular/audio/etc dataset, and then run the same code to discover what sort of issues lurk within it!"
+   ]
+  },
+  {
+   "attachments": {},
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "<div class=\"alert alert-info\">\n",
+    "Quickstart\n",
+    "<br/>\n",
+    "    \n",
+    "Already have (out-of-sample) `pred_probs` from a model trained on an existing set of labels? Maybe you have some `features` as well? Run the code below to examine your dataset for multiple types of issues.\n",
+    "\n",
+    "<div  class=markdown markdown=\"1\" style=\"background:white;margin:16px\">  \n",
+    "    \n",
+    "```ipython3 \n",
+    "from cleanlab import Datalab\n",
+    "\n",
+    "lab = Datalab(data=your_dataset, label_name=\"column_name_of_labels\")\n",
+    "\n",
+    "lab.find_issues(features=your_feature_matrix, pred_probs=your_pred_probs)\n",
+    "\n",
+    "lab.report()\n",
+    "```\n",
+    "   \n",
+    "</div>\n",
+    "</div>"
    ]
   },
   {

--- a/docs/source/tutorials/scripts/data_generation.py
+++ b/docs/source/tutorials/scripts/data_generation.py
@@ -117,6 +117,8 @@ def plot_data(X_train, y_train_idx, noisy_labels_idx, X_out):
 
     # Plot true boundaries (x+y=3.3, x+y=6.6)
     for i in range(2):
+        ax[i].set_xlim(-3.5, 8.5)
+        ax[i].set_ylim(-3.5, 8.5)
         ax[i].plot([-0.7, 4.0], [4.0, -0.7], color="k", linestyle="--", alpha=0.5)
         ax[i].plot([-0.7, 7.3], [7.3, -0.7], color="k", linestyle="--", alpha=0.5)
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,7 +1,6 @@
 # Python dependencies for development
 coverage != 6.3, != 6.3.*
 datasets
-fast-histogram
 hypothesis
 mypy
 pandas-stubs

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,7 @@ DATALAB_REQUIRE = [
 
 EXTRAS_REQUIRE = {
     "datalab": DATALAB_REQUIRE,
-    "all": [
-        # Used by the NonIIDIssueManager
-        # for computing 1D histograms efficiently.
-        "fast-histogram>=0.11"
-    ],
+    "all": [],
 }
 EXTRAS_REQUIRE["all"] = list(set(sum(EXTRAS_REQUIRE.values(), [])))
 

--- a/tests/datalab/test_knn.py
+++ b/tests/datalab/test_knn.py
@@ -74,6 +74,57 @@ class TestKNN:
         ), "Should warn if n_neighbors does not match"
         assert "Using the n_neighbors found in the existing KNN search object." in warn_message
 
+    def test_default_attributes(self) -> None:
+        """Test that the default attributes are set correctly.
+
+        Specifically, the metric and number of neighbors should be set to the same values as the
+        knn search object.
+        """
+
+        # List of tuples of (kwargs, expected attributes)
+        test_kwargs_and_expected_attribute_tuples = [
+            # n_neighbors and metric take values from the default knn search object
+            ({}, {"n_neighbors": 5, "knn": NearestNeighbors, "metric": "minkowski"}),
+            # knn search object is still the default, but it's n_neighbors is overridden
+            (
+                {"n_neighbors": 10},
+                {"n_neighbors": 10, "knn": NearestNeighbors, "metric": "minkowski"},
+            ),
+            # metric is also overridden
+            (
+                {"n_neighbors": 7, "metric": "euclidean"},
+                {"n_neighbors": 7, "knn": NearestNeighbors, "metric": "euclidean"},
+            ),
+            # passing a knn search object overrides n_neighbors and metric
+            (
+                {"n_neighbors": 7, "knn": AnnoyKNN()},
+                {"n_neighbors": 5, "knn": AnnoyKNN, "metric": "angular"},
+            ),
+            # passing a knn search object overrides n_neighbors and metric
+            (
+                {
+                    "n_neighbors": 2,
+                    "knn": NearestNeighbors(n_neighbors=8, metric="cosine"),
+                    "metric": "euclidean",
+                },
+                {"n_neighbors": 8, "knn": NearestNeighbors, "metric": "cosine"},
+            ),
+        ]
+
+        for i, (kwargs, expected_attributes) in enumerate(
+            test_kwargs_and_expected_attribute_tuples
+        ):
+            knn = KNN(**kwargs)
+            assert (
+                knn.n_neighbors == expected_attributes["n_neighbors"]
+            ), f"Failing on n_neighbors for test case {i}"
+            assert isinstance(
+                knn.knn, expected_attributes["knn"]
+            ), f"Failing on knn for test case {i}"
+            assert (
+                knn.metric == expected_attributes["metric"]
+            ), f"Failing on metric for test case {i}"
+
     def test_fit(self, knn: KNN, features: np.ndarray) -> None:
         assert knn._fit_features is None
         fit_object = knn.fit(features)

--- a/tests/datalab/test_knn.py
+++ b/tests/datalab/test_knn.py
@@ -69,7 +69,9 @@ class TestKNN:
             ), "KNN object should override n_neighbors"
         assert len(record) == 1
         warn_message = record[0].message.args[0]
-        assert "n_neighbors 3 does not match n_neighbors 5 used to fit knn" in warn_message
+        assert (
+            "n_neighbors 3 does not match n_neighbors 5 used to fit knn" in warn_message
+        ), "Should warn if n_neighbors does not match"
         assert "Using the n_neighbors found in the existing KNN search object." in warn_message
 
     def test_fit(self, knn: KNN, features: np.ndarray) -> None:
@@ -126,7 +128,7 @@ class TestKNN:
 
     def test_kneighbors_graph_features(self, knn: KNN, features: np.ndarray) -> None:
         knn.fit(features)
-        N_new = 5
+        N_new = 25
         new_features = np.random.rand(N_new, 2)
         graph = knn.kneighbors_graph(new_features)
         assert graph.shape == (N_new, N_new)

--- a/tests/datalab/test_knn.py
+++ b/tests/datalab/test_knn.py
@@ -1,0 +1,110 @@
+from typing import Optional, Tuple
+from annoy import AnnoyIndex
+import numpy as np
+import pytest
+from timeit import timeit
+from sklearn.neighbors import NearestNeighbors
+
+from cleanlab.experimental.datalab.knn import KNN, KNNInterface
+
+
+class AnnoyKNN(KNNInterface):
+    """Annoy class that is compatible with sklearn API."""
+
+    def __init__(self, n_neighbors: int = 5, metric: str = "angular", n_trees: int = 10):
+        self.ann_index = None
+        self.n_neighbors = n_neighbors
+        self.metric = metric
+        self.n_trees = n_trees
+
+    def fit(self, features: np.ndarray):
+        dim = features.shape[1]
+        self.ann_index = AnnoyIndex(dim, metric=self.metric)
+        for i, x in enumerate(features):
+            self.ann_index.add_item(i, x)
+        self.ann_index.build(self.n_trees)
+        return self
+
+    def kneighbors(self, features: np.ndarray, n_neighbors: int = None):
+        distances = []
+        indices = []
+        for x in features:
+            idx, dist = self.ann_index.get_nns_by_vector(
+                x, n_neighbors or self.n_neighbors, include_distances=True
+            )
+            distances.append(dist)
+            indices.append(idx)
+        distances = np.array(distances)
+        indices = np.array(indices)
+        return distances, indices
+
+
+class TestKNN:
+    # @pytest.mark.parametrize("index", [MockKNN(n_neighbors=3), AnnoyKNN(n_neighbors=3)])
+    @pytest.fixture(
+        params=[NearestNeighbors(n_neighbors=3), AnnoyKNN(n_neighbors=3)], ids=["Sklearn", "Annoy"]
+    )
+    def knn(self, request) -> KNN:
+        # Assuming each index has a larger n_neighbors than is passed to KNN
+
+        return KNN(n_neighbors=2, knn=request.param)
+
+    @pytest.fixture
+    def features(self) -> np.ndarray:
+        return np.random.rand(10, 2)
+
+    def test_init(self, knn: KNN) -> None:
+        assert knn.n_neighbors == 3
+
+        assert knn.neighbor_indices is None
+        assert knn.neighbor_distances is None
+
+        assert KNN(n_neighbors=4).n_neighbors == 4
+
+        with pytest.warns(UserWarning) as record:
+            larger_index: KNNInterface = NearestNeighbors(n_neighbors=5)
+            assert (
+                KNN(n_neighbors=3, knn=larger_index).n_neighbors == 5
+            ), "KNN object should override n_neighbors"
+        assert len(record) == 1
+        warn_message = record[0].message.args[0]
+        assert "n_neighbors 3 does not match n_neighbors 5 used to fit knn" in warn_message
+        assert "Using the n_neighbors found in the existing KNN search object." in warn_message
+
+    def test_fit(self, knn: KNN, features: np.ndarray) -> None:
+        assert knn._fit_features is None
+        fit_object = knn.fit(features)
+        assert np.all(knn._fit_features == features)
+        assert isinstance(fit_object, KNN)
+
+    def test_kneighbors(self, knn: KNN, features: np.ndarray) -> None:
+        knn.fit(features)
+        time_1 = timeit(lambda: knn.kneighbors(), number=1)
+        time_2 = timeit(lambda: knn.kneighbors(), number=1)
+
+        assert time_1 > time_2, "KNN should cache results, so second call should be faster"
+        neighbor_distances, neighbor_indices = knn.kneighbors()
+
+        assert neighbor_distances.shape == (10, 3)
+        assert neighbor_indices.shape == (10, 3)
+        assert neighbor_distances.dtype == np.float64
+        assert neighbor_indices.dtype == np.int64
+        assert np.all(
+            neighbor_distances[:, 0] != 0
+        ), "First neighbor should not be itself when calling knn.kneighbors()"
+
+        # Query with same features
+        neighbor_distances, neighbor_indices = knn.kneighbors(features)
+        assert neighbor_distances.shape == (10, 3)
+        assert neighbor_indices.shape == (10, 3)
+        assert np.all(
+            neighbor_distances[:, 0] == 0
+        ), "knn.kneighbors(features) includes query points as their own nearest neighbors"
+
+    def test_kneighbors_graph(self, knn: KNN, features: np.ndarray) -> None:
+        knn.fit(features)
+        graph = knn.kneighbors_graph()
+        assert graph.shape == (10, 10)
+        assert np.all(graph.diagonal() == 0)
+        assert np.all(graph.data >= 0)
+        assert graph.nnz == features.shape[0] * knn.n_neighbors

--- a/tests/datalab/test_knn.py
+++ b/tests/datalab/test_knn.py
@@ -3,6 +3,7 @@ from annoy import AnnoyIndex
 import numpy as np
 import pytest
 from timeit import timeit
+from sklearn.exceptions import NotFittedError
 from sklearn.neighbors import NearestNeighbors
 
 from cleanlab.experimental.datalab.knn import KNN, KNNInterface
@@ -76,6 +77,14 @@ class TestKNN:
         fit_object = knn.fit(features)
         assert np.all(knn._fit_features == features)
         assert isinstance(fit_object, KNN)
+
+    def test_kneighbors_raises_error_if_not_fit(self, knn: KNN, features: np.ndarray) -> None:
+        with pytest.raises(NotFittedError) as record:
+            knn.kneighbors(features)
+        expected_message = (
+            "KNN search object not fit, cannot find neighbors. Call the fit() method first."
+        )
+        assert expected_message in record.value.args[0]
 
     def test_kneighbors(self, knn: KNN, features: np.ndarray) -> None:
         knn.fit(features)

--- a/tests/datalab/test_knn.py
+++ b/tests/datalab/test_knn.py
@@ -117,3 +117,21 @@ class TestKNN:
         assert np.all(graph.diagonal() == 0)
         assert np.all(graph.data >= 0)
         assert graph.nnz == features.shape[0] * knn.n_neighbors
+
+    def test_kneighbors_graph_cache(self, knn: KNN, features: np.ndarray) -> None:
+        knn.fit(features)
+        time_1 = timeit(lambda: knn.kneighbors_graph(), number=1)
+        time_2 = timeit(lambda: knn.kneighbors_graph(), number=1)
+        assert time_1 > time_2, "KNN should cache results, so second call should be faster"
+
+    def test_kneighbors_graph_features(self, knn: KNN, features: np.ndarray) -> None:
+        knn.fit(features)
+        N_new = 5
+        new_features = np.random.rand(N_new, 2)
+        graph = knn.kneighbors_graph(new_features)
+        assert graph.shape == (N_new, N_new)
+        assert np.any(
+            graph.diagonal() != 0
+        ), "Diagonal doesn't have to be zero when querying with different features"
+        assert np.all(graph.data >= 0)
+        assert graph.nnz == N_new * knn.n_neighbors

--- a/tests/datalab/test_knn.py
+++ b/tests/datalab/test_knn.py
@@ -189,6 +189,28 @@ class TestKNN:
         assert np.all(graph.data >= 0)
         assert graph.nnz == N_new * knn.n_neighbors
 
+    def test_radius_neighbors(self, features: np.ndarray) -> None:
+        knn = KNN()
+        knn.fit(features)
+        knn.radius_neighbors()  # Default values should work
+        neighbor_indices = knn.radius_neighbors(radius=0.2)
+        assert neighbor_indices.shape == (10,)
+        for indices in neighbor_indices:
+            assert isinstance(indices, np.ndarray)
+            assert indices.dtype == np.int64
+
+        # Annoy doesn't support radius search at the moment
+        knn = KNN(knn=AnnoyKNN())
+        knn.fit(features)
+        with pytest.raises(NotImplementedError) as record:
+            knn.radius_neighbors(radius=0.2)
+        error_message = record.value.args[0]
+        assert "KNN search object does not have a radius_neighbors method." in error_message
+        assert (
+            "For now, only sklearn.neighbors.NearestNeighbors objects support the radius_neighbors method out of the box."
+            in error_message
+        )
+
     def test_add_item(self, knn: KNN) -> None:
         """Test that add_item() adds a new item to the index (without modifying existing items)"""
         assert knn._fit_features is None

--- a/tests/datalab/test_knn.py
+++ b/tests/datalab/test_knn.py
@@ -1,4 +1,3 @@
-from typing import Optional, Tuple
 from annoy import AnnoyIndex
 import numpy as np
 import pytest


### PR DESCRIPTION
# Description

This PR adds a new feature internally used by Datalab: a wrapper for K-nearest neighbors (KNN) search. 

This involves two new classes:

- `KNN`: Handles the knn search and graph construction.
- `KNNInterface`: Defines the necessary interface to maintain sklearn compatibility.

The `KNN` class is used to find the K nearest neighbors of data points in a dataset and represent the set of nearest neighbors as weighted graph adjacency matrix (excluding self-loops).

The `KNN` class optionally takes a vector search index (that must implement the `KNNInterface`), which requires that any class handling KNN search be compatible with Datalab. These indexes can be:

- `NearestNeighbors` from sklearn
- `AnnoyIndex` from annoy
- `IndexXYZ`/`index_factory(...)` from faiss.

**The indexes must be adapted to the `KNNInterface`**

## More details

The KNN class has a constructor (`__init__`), a `fit` method for fitting the data, and three other methods:

- `kneighbors`: This method returns the K nearest neighbors of a given point in the dataset.
- `kneighbors_graph`: This method returns a weighted graph adjacency matrix that represents the dataset. Each node in the graph represents a data point, and edges represent the connections between the K nearest neighbors, weighted by their distances.
- `radius_neighbors`: This method returns all the data points within a given radius of a query point.

Additionally, the `KNN` class has an `add_item` method that allows you to add new data points to the dataset without re-fitting the entire dataset.

This wrapper is a valuable addition to the codebase for handling KNN search and representing datasets as graphs, while supporting different search backends.

The main functionality of the `KNN` class has been tested.