### PR TITLE
Update Python version to 3.11 in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,7 @@ jobs:
       matrix:
         python:
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -44,6 +45,7 @@ jobs:
           - macos-latest
         python:
           - "3.11"
+          - "3.12"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,10 +11,7 @@ jobs:
     strategy:
       matrix:
         python:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -46,10 +43,7 @@ jobs:
           - ubuntu-latest
           - macos-latest
         python:
-          - "3.7"
-          - "3.8"
-          - "3.9"
-          - "3.10"
+          - "3.11"
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4


### PR DESCRIPTION
Playing around with CI working on Python 3.11. Specifically with MacOS and Windows.