### PR TITLE
Update pytest version in requirements-dev.txt to be compatible with v7.4

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,7 +6,7 @@ mypy
 pandas-stubs
 pre-commit
 psutil
-pytest
+pytest~=7.4
 pytest-cov
 requests
 scipy


### PR DESCRIPTION
See if capping pytest version fixes failing KerasModelWrapper test.

v.8.0.0 release of pytest is a possible culprit of the failing test. Still not sure why.